### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/sterile.gemspec
+++ b/sterile.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Sterilize your strings! Transliterate, generate slugs, smart format, strip tags, encode/decode entities and more.}
   s.description = s.summary
 
-  s.rubyforge_project = "sterile"
-
   s.add_dependency("nokogiri")
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436