### PR TITLE
gemspec: Add a license note

### DIFF
--- a/sterile.gemspec
+++ b/sterile.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Patrick Hogan"]
   s.email       = ["pbhogan@gmail.com"]
   s.homepage    = "https://github.com/pbhogan/sterile"
+  s.licenses    = ['MIT']
   s.summary     = %q{Sterilize your strings! Transliterate, generate slugs, smart format, strip tags, encode/decode entities and more.}
   s.description = s.summary
 


### PR DESCRIPTION
This has the effect of making it easier to auto-detect with tools, such as GitHub, or a license_finder gem.